### PR TITLE
little change to be able to update just the value

### DIFF
--- a/dist/circle-progress.js
+++ b/dist/circle-progress.js
@@ -134,7 +134,7 @@ $.fn.circleProgress = function(config) {
         if (typeof config == 'undefined' || config == 'redraw') {
             options = data.options;
         } else {
-            options = $.extend({}, $.circleProgress.defaults, config);
+            options = $.extend({}, $.circleProgress.defaults, data.options, config);
             data.options = options;
         }
 


### PR DESCRIPTION
While uploading a file I wanted to update circleProgress `value` in the onprogress handler of the uploadscript.

```
$('input[type=file]').fileupload({
    // ...
}).on('fileuploadadd', function(e, data) {
    // ....
    // here I init my circleProgress:
    $('#circle-progress').circleProgress({
        value: 0,
        size: 32,
        animation: false,
        fill: { gradient: ['#0681c4', '#07c6c1'] },
        startAngle: Math.PI * 1.5,
        thickness: 0
    });
}).on('fileuploadprogress', function(e, data) {
    // ...
    // here I just update the value:
    $('#circle-progress').circleProgress({
        value: progress
    });
});
```

Without this change the update call redraws the circleProgress with the defaults, now it uses the `data.options` where all previous options are stored...
