### PR TITLE
Add support for empty frame values & animation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+bower_components/
+node_modules/
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 0.10
+  - 4.4.7
 before_script:
   - npm install -g bower karma-cli
   - bower install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,12 @@
 language: node_js
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
 node_js:
   - 6.0.0
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ node_js:
 before_script:
   - npm install -g bower karma-cli
   - bower install
+  - cd bower_components/modernizr
+  - npm install
+  - ./bin/modernizr -c lib/config-all.json
+  - cd ../..
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 4.4.7
+  - 6.0.0
 before_script:
   - npm install -g bower karma-cli
   - bower install

--- a/bower.json
+++ b/bower.json
@@ -24,6 +24,6 @@
     },
     "devDependencies": {
         "qunit": "1.15.0",
-        "modernizr": "2.8.3"
+        "modernizr": "*"
     }
 }

--- a/bower.json
+++ b/bower.json
@@ -24,6 +24,6 @@
     },
     "devDependencies": {
         "qunit": "1.15.0",
-        "modernizr": "*"
+        "modernizr": "2.8.3"
     }
 }

--- a/dist/circle-progress.js
+++ b/dist/circle-progress.js
@@ -74,6 +74,8 @@ License: MIT
             easing: 'circleProgressEasing'
         },
 
+        animateEmpty: false,
+
         /**
          * Default animation starts at 0.0 and ends at specified `value`. Let's call this direct animation.
          * If you want to make reversed animation then you should set `animationStartValue` to 1.0.
@@ -250,7 +252,7 @@ License: MIT
         },
 
         draw: function() {
-            if (this.animation)
+            if (this.animation || this.animateEmpty)
                 this.drawAnimated(this.value, this.emptyFillValue);
             else
                 this.drawFrame(this.value, this.emptyFillValue);
@@ -356,7 +358,7 @@ License: MIT
                 .animate({ animationProgress: 1 }, $.extend({}, this.animation, {
                     step: function (animationProgress) {
                         var stepValue = self.animationStartValue * (1 - animationProgress) + v * animationProgress;
-                        var emptyStepValue = self.emptyAnimationStartValue * (1 - animationProgress) + e * animationProgress;
+                        var emptyStepValue = self.animateEmpty ? self.emptyAnimationStartValue * (1 - animationProgress) + e * animationProgress : self.emptyFillValue;
                         self.drawFrame(stepValue, emptyStepValue);
                         el.trigger('circle-animation-progress', [animationProgress, stepValue]);
                     }

--- a/tests/index.html
+++ b/tests/index.html
@@ -10,7 +10,7 @@
     <div id="qunit-fixture"></div>
 
     <script src="../bower_components/jquery/dist/jquery.min.js"></script>
-    <script src="../bower_components/modernizr/src/Modernizr.js"></script>
+    <script src="../bower_components/modernizr/modernizr.js"></script>
     <script src="../bower_components/qunit/qunit/qunit.js"></script>
     <script src="../dist/circle-progress.js"></script>
     <script src="test_utils.js"></script>

--- a/tests/index.html
+++ b/tests/index.html
@@ -10,8 +10,7 @@
     <div id="qunit-fixture"></div>
 
     <script src="../bower_components/jquery/dist/jquery.min.js"></script>
-    <!-- <script src="../bower_components/modernizr/modernizr.js"></script> -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.js"></script>
+    <script src="../bower_components/modernizr/modernizr.js"></script>
     <script src="../bower_components/qunit/qunit/qunit.js"></script>
     <script src="../dist/circle-progress.js"></script>
     <script src="test_utils.js"></script>

--- a/tests/index.html
+++ b/tests/index.html
@@ -10,7 +10,7 @@
     <div id="qunit-fixture"></div>
 
     <script src="../bower_components/jquery/dist/jquery.min.js"></script>
-    <script src="../bower_components/modernizr/modernizr.js"></script>
+    <script src="../bower_components/modernizr/src/Modernizr.js"></script>
     <script src="../bower_components/qunit/qunit/qunit.js"></script>
     <script src="../dist/circle-progress.js"></script>
     <script src="test_utils.js"></script>

--- a/tests/index.html
+++ b/tests/index.html
@@ -10,7 +10,8 @@
     <div id="qunit-fixture"></div>
 
     <script src="../bower_components/jquery/dist/jquery.min.js"></script>
-    <script src="../bower_components/modernizr/modernizr.js"></script>
+    <!-- <script src="../bower_components/modernizr/modernizr.js"></script> -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.js"></script>
     <script src="../bower_components/qunit/qunit/qunit.js"></script>
     <script src="../dist/circle-progress.js"></script>
     <script src="test_utils.js"></script>

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -148,7 +148,7 @@
             assert.expect(9);
             image.src = imageUrl;
 
-            $(image).load(function() {
+            $(image).on('load', function() {
                 var canvas = createCircle({
                     value: 0.5,
                     thickness: 20,


### PR DESCRIPTION
I made a few changes that adds support for empty fill values (and animation). An example use case for something like this is visually representing loading/playing audio: it first has to load the audio (which can now be shown using empty fill), then play the audio (which can be used with normal fill, as before). This PR is a response to issue #106.