### PR TITLE
Revert to modernizr to 2 8 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: node_js
 node_js:
   - 0.10
-before_script:
-  - npm install -g bower karma-cli
-  - bower install
+before_install:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
+install:
+  - npm install -g bower
+  - npm install
+  - bower install
 env:
   global:
     - secure: Z6oEIaybr8vkGTZZbDJJT+9wO4SjRdXq5AV1dlgrQZ0j2wSXmP6Q4HeL8jWWt6RFOZvMyNLq+X6KwWSAsIB7B8TRF1mBrX++MBKINj+oUUYAAhPU9yl8iwgvQLh3suER1OvB0BP/LdeFCZ8zSG2UPI1KRqk4ZdFKwEg0u4CSQvo=

--- a/bower.json
+++ b/bower.json
@@ -24,6 +24,6 @@
     },
     "devDependencies": {
         "qunit": "1.15.0",
-        "modernizr": "*"
+        "modernizr": "2.8.3"
     }
 }


### PR DESCRIPTION
Revert modernizr to older version which works with jquery-circle-progress.  The bower config is grabbing the lastest version which seems to be incompatible with our tests.

Updated the travis config to have an explict npm so that we grab all of the needed bits.

My travis log in case your impatient:
  https://travis-ci.org/dougt/jquery-circle-progress/builds/152572251
