### PR TITLE
Fix tests after moved out of jQuery and handle retina support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
 language: node_js
 node_js:
-  - 0.10
+  - 5.0.0
 before_script:
   - npm install -g bower karma-cli
   - bower install
+  - cd bower_components/modernizr
+  - npm install
+  - ./bin/modernizr -c lib/config-all.json
+  - cd ../..
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ before_script:
   - cd ../..
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
+addons:
+  firefox: latest
 env:
   global:
     - secure: Z6oEIaybr8vkGTZZbDJJT+9wO4SjRdXq5AV1dlgrQZ0j2wSXmP6Q4HeL8jWWt6RFOZvMyNLq+X6KwWSAsIB7B8TRF1mBrX++MBKINj+oUUYAAhPU9yl8iwgvQLh3suER1OvB0BP/LdeFCZ8zSG2UPI1KRqk4ZdFKwEg0u4CSQvo=

--- a/dist/circle-progress.js
+++ b/dist/circle-progress.js
@@ -157,6 +157,13 @@ License: MIT
             canvas.width = this.size;
             canvas.height = this.size;
             this.ctx = canvas.getContext('2d');
+
+            if (window.devicePixelRatio > 1) {
+                var scaleBy = window.devicePixelRatio;
+                canvas.style.width = canvas.style.height = [this.size, 'px'].join('');
+                canvas.width = canvas.height = this.size * scaleBy;
+                this.ctx.scale(scaleBy, scaleBy);
+            }
         },
 
         /**

--- a/karma-saucelabs.conf.js
+++ b/karma-saucelabs.conf.js
@@ -39,6 +39,7 @@ module.exports = function(config) {
         frameworks: ['qunit'],
         files: [
             { pattern: 'tests/images/circle.png', served: true, watched: false, included: false },
+            'bower_components/jquery/dist/jquery.js',
             'bower_components/modernizr/modernizr.js',
             'dist/circle-progress.js',
             'tests/test_utils.js',

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -4,9 +4,10 @@ module.exports = function(config) {
         frameworks: ['qunit'],
         files: [
             { pattern: 'tests/images/circle.png', served: true, watched: false, included: false },
+            'bower_components/jquery/dist/jquery.js',
             'bower_components/modernizr/modernizr.js',
             'dist/circle-progress.js',
-            'tests/test-utils.js',
+            'tests/test_utils.js',
             'tests/tests.js'
         ],
         browsers: ['Firefox', 'PhantomJS'],

--- a/tests/index.html
+++ b/tests/index.html
@@ -9,7 +9,7 @@
     <div id="qunit"></div>
     <div id="qunit-fixture"></div>
 
-    <script src="../bower_components/jquery/dist/jquery.min.js"></script>
+    <script src="../bower_components/jquery/dist/jquery.js"></script>
     <script src="../bower_components/modernizr/modernizr.js"></script>
     <script src="../bower_components/qunit/qunit/qunit.js"></script>
     <script src="../dist/circle-progress.js"></script>

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1,4 +1,4 @@
-(function() {
+(function($) {
     // TODO: temporarily set easing because of the non defined easing in $.animate
     CircleProgress.prototype.animation.easing = 'linear';
 
@@ -189,6 +189,7 @@
     // Utilities
     function createCircle(cfg) {
         var output = $('#qunit-fixture');
+
         if (!output[0])
             output = $('body');
         var el = $('<span>').appendTo(output);
@@ -199,4 +200,4 @@
 
         return instance.canvas;
     }
-})();
+})(jQuery);

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -180,6 +180,36 @@
                 }, 1400);
             });
         });
+
+        QUnit.test("Test it renders correctly on retina", function(assert) {
+            /**
+             * Mock devicePixelRatio
+             */
+            window.devicePixelRatio = 2;
+
+            var canvas = createCircle({
+                value: 0.75,
+                size: 50
+            });
+
+            assert.equal(50 + 'px', $(canvas).css('width'));
+            assert.equal(100, canvas.width);
+        });
+
+        QUnit.test("Test it renders correctly on regular pixel density", function(assert) {
+            /**
+             * Mock devicePixelRatio
+             */
+            window.devicePixelRatio = 1;
+
+            var canvas = createCircle({
+                value: 0.75,
+                size: 50
+            });
+
+            assert.equal(50 + 'px', $(canvas).css('height'));
+            assert.equal(50, canvas.width);
+        });
     } else {
         QUnit.test("Your browser doesn't support Canvas", function(assert) {
             assert.ok(true, "That's fine");

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1,4 +1,7 @@
 (function() {
+    // TODO: temporarily set easing because of the non defined easing in $.animate
+    CircleProgress.prototype.animation.easing = 'linear';
+
     if (Modernizr.canvas) {
         QUnit.module("Layout tests, no animation");
 
@@ -8,8 +11,8 @@
                 defaultSize = 100,
                 defaultThickness = parseInt(defaultSize / 14); // 7
 
-            assert.equal($.circleProgress.defaults.size, defaultSize, "Default circle size: 100 pixels");
-            assert.equal($.circleProgress.defaults.thickness, 'auto', "Default circle thickness: 'auto' (i.e. 1/14 of size)");
+            assert.equal(CircleProgress.prototype.size, defaultSize, "Default circle size: 100 pixels");
+            assert.equal(CircleProgress.prototype.thickness, 'auto', "Default circle thickness: 'auto' (i.e. 1/14 of size)");
             assert.equal(canvas.tagName.toLowerCase(), 'canvas', "Method .circleProgress('widget') returns HTMLCanvasElement");
             assert.equal($canvas.width(), defaultSize, "Default width: 100 pixels");
             assert.equal($canvas.height(), defaultSize, "Default height: 100 pixels");
@@ -23,7 +26,7 @@
                     value: 0.5,
                     animation: false
                 }),
-                size = $.circleProgress.defaults.size;
+                size = CircleProgress.prototype.size;
 
             assert.pixelCloseHex(canvas, 1, size / 2 - 1, '#3aeabb', 0.015);
             assert.pixelCloseRGBA(canvas, 1, size / 2 + 1, 'rgba(0, 0, 0, 0.1)', 0.01);
@@ -42,7 +45,7 @@
                     fill: { color: color },
                     animation: false
                 }),
-                defaultSize = $.circleProgress.defaults.size;
+                defaultSize = CircleProgress.prototype.size;
 
             assert.pixelHex(canvas, 1, defaultSize / 2 - 1, color);
             assert.pixelHex(canvas, defaultSize - 1, defaultSize / 2 - 1, color);
@@ -56,7 +59,7 @@
                     value: 0.5,
                     fill: { color: color }
                 }),
-                size = $.circleProgress.defaults.size;
+                size = CircleProgress.prototype.size;
 
             assert.expect(8);
             QUnit.stop();
@@ -148,7 +151,7 @@
             assert.expect(9);
             image.src = imageUrl;
 
-            $(image).load(function() {
+            $(image).ready(function() {
                 var canvas = createCircle({
                     value: 0.5,
                     thickness: 20,
@@ -188,7 +191,12 @@
         var output = $('#qunit-fixture');
         if (!output[0])
             output = $('body');
-        var el = $('<span>').appendTo(output).circleProgress(cfg);
-        return el.circleProgress('widget');
+        var el = $('<span>').appendTo(output);
+
+        var instance = new CircleProgress($.extend({
+            el: el
+        }, cfg));
+
+        return instance.canvas;
     }
 })();


### PR DESCRIPTION
This pull request is re-born #83. Due to the fact that 8910413 moved this library out of jQuery, the tests also should've been refactored and get into shape. jQuery is still needed for tests, unfortunately. Also it handles `Modernizr` building correctly in [tests](https://github.com/andreiglingeanu/jquery-circle-progress/blob/3688da3421d5748033e9cca99fa1687a2e6d7bb2/.travis.yml#L9).

<hr>

And, to not forget:

> This pull request will make circles look cool on devices that have `devicePixelRatio` bigger than one.

Yay!